### PR TITLE
Fix syntax error on line#186 of `tuntap-unix-freebsd.c`

### DIFF
--- a/tuntap-unix-freebsd.c
+++ b/tuntap-unix-freebsd.c
@@ -183,7 +183,7 @@ tuntap_sys_set_ipv4(struct device *dev, t_tun_in_addr *s4, uint32_t bits) {
 	/* Set the address */
 	(void)memset(&addr, '\0', sizeof addr);
 	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = s4.s_addr;
+	addr.sin_addr.s_addr = s4->s_addr;
 	addr.sin_len = sizeof addr;
 	(void)memcpy(&ifr.ifr_addr, &addr, sizeof addr);
 


### PR DESCRIPTION
`s4` is a `t_tun_in_addr *`, so using `s4.s_addr` should be `s4->s_addr` on line 186 of `tuntap-unix-freebsd.c`