### PR TITLE
Complete FreeBSD support, also fix 'tun' device for it.

### DIFF
--- a/regress/test14.c
+++ b/regress/test14.c
@@ -36,7 +36,7 @@ main(void) {
 		return 1;
 	}
 
-	if (tuntap_set_ip(dev, "1.2.3.4", 24) == -1) {
+	if (tuntap_set_ip(dev, "1.2.3.4", 24, "4.3.2.1") == -1) {
 		return 1;
 	}
 

--- a/regress/test18.c
+++ b/regress/test18.c
@@ -32,7 +32,7 @@ main(void) {
 		return 1;
 	}
 
-	if (tuntap_set_ip(dev, "1.2.3.4", 24) == -1) {
+	if (tuntap_set_ip(dev, "1.2.3.4", 24, "4.3.2.1") == -1) {
 		return 1;
 	}
 

--- a/regress/test33.sh
+++ b/regress/test33.sh
@@ -30,11 +30,11 @@ else
 	return 1
 fi
 
-# The $TARGET still exists, clean it and return failure
+# Everything went fine
 if [ $OK -eq 2 ]; then
 	$IFDEL
-	return 1
+	return 0
 fi
 
-# Everything went fine
-return 0
+# The $TARGET still exists, return failure
+return 1

--- a/regress/test34.sh
+++ b/regress/test34.sh
@@ -26,7 +26,7 @@ fi
 # The $TARGET still exists
 if [ $OK -eq 2 ]; then
 	$IFDEL
-	return 1
+	return 0
 fi
 
-return 0
+return 1

--- a/tuntap-unix-freebsd.c
+++ b/tuntap-unix-freebsd.c
@@ -84,12 +84,12 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 	/* Try to use the given driver or loop throught the avaible ones */
 	fd = -1;
 	if (tun < TUNTAP_ID_MAX) {
-		(void)snprintf(name, sizeof name, "/dev/%s%i", ifname, tun);
+		(void)snprintf(name, sizeof(name), "/dev/%s%i", ifname, tun);
 		fd = open(name, O_RDWR);
 	} else if (tun == TUNTAP_ID_ANY) {
 		for (tun = 0; tun < TUNTAP_ID_MAX; ++tun) {
-			(void)memset(name, 0, sizeof name);
-			(void)snprintf(name, sizeof name, "/dev/%s%i",
+			(void)memset(name, 0, sizeof(name));
+			(void)snprintf(name, sizeof(name), "/dev/%s%i",
 			    ifname, tun);
 			if ((fd = open(name, O_RDWR)) > 0)
 				break;
@@ -111,10 +111,10 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 	}
 
 	/* Set the interface name */
-	(void)memset(&ifr, 0, sizeof ifr);
-	(void)snprintf(ifr.ifr_name, sizeof ifr.ifr_name, "%s%i", ifname, tun);
+	(void)memset(&ifr, 0, sizeof(ifr));
+	(void)snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s%i", ifname, tun);
 	/* And save it */
-	(void)strlcpy(dev->if_name, ifr.ifr_name, sizeof dev->if_name);
+	(void)strlcpy(dev->if_name, ifr.ifr_name, sizeof(dev->if_name));
 
 	/* Get the interface default values */
 	if (ioctl(dev->ctrl_sock, SIOCGIFFLAGS, &ifr) == -1) {
@@ -169,8 +169,8 @@ int
 tuntap_sys_set_hwaddr(struct device *dev, struct ether_addr *eth_addr) {
 	struct ifreq ifr;
 
-	(void)memset(&ifr, 0, sizeof ifr);
-	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
+	(void)memset(&ifr, 0, sizeof(ifr));
+	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof(ifr.ifr_name));
 	ifr.ifr_addr.sa_len = ETHER_ADDR_LEN;
 	ifr.ifr_addr.sa_family = AF_LINK;
 	(void)memcpy(ifr.ifr_addr.sa_data, eth_addr, ETHER_ADDR_LEN);
@@ -187,25 +187,25 @@ tuntap_sys_set_ipv4_tap(struct device *dev, t_tun_in_addr *s4, uint32_t bits) {
 	struct sockaddr_in mask;
 	struct sockaddr_in addr;
 
-	(void)memset(&ifrq, 0, sizeof ifrq);
-	(void)strlcpy(ifrq.ifra_name, dev->if_name, sizeof ifrq.ifra_name);
+	(void)memset(&ifrq, 0, sizeof(ifrq));
+	(void)strlcpy(ifrq.ifra_name, dev->if_name, sizeof(ifrq.ifra_name));
 
 	/* Delete previously assigned address */
 	(void)ioctl(dev->ctrl_sock, SIOCDIFADDR, &ifrq);
 
 	/* Set the address */
-	(void)memset(&addr, 0, sizeof addr);
+	(void)memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = s4->s_addr;
-	addr.sin_len = sizeof addr;
-	(void)memcpy(&ifrq.ifra_addr, &addr, sizeof addr);
+	addr.sin_len = sizeof(addr);
+	(void)memcpy(&ifrq.ifra_addr, &addr, sizeof(addr));
 
 	/* Then set the netmask */
-	(void)memset(&mask, 0, sizeof mask);
+	(void)memset(&mask, 0, sizeof(mask));
 	mask.sin_family = AF_INET;
 	mask.sin_addr.s_addr = bits;
-	mask.sin_len = sizeof mask;
-	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof ifrq.ifra_mask);
+	mask.sin_len = sizeof(mask);
+	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof(ifrq.ifra_mask));
 
 	if (ioctl(dev->ctrl_sock, SIOCAIFADDR, &ifrq) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't set IP address/netmask");
@@ -222,31 +222,31 @@ tuntap_sys_set_ipv4_tun(struct device *dev, t_tun_in_addr *s4, t_tun_in_addr *s4
 	struct sockaddr_in saddr;
 	struct sockaddr_in daddr;
 
-	(void)memset(&ifrq, 0, sizeof ifrq);
-	(void)memcpy(ifrq.ifra_name, dev->if_name, sizeof ifrq.ifra_name);
+	(void)memset(&ifrq, 0, sizeof(ifrq));
+	(void)memcpy(ifrq.ifra_name, dev->if_name, sizeof(ifrq.ifra_name));
 
 	/* Delete previously assigned address */
 	(void)ioctl(dev->ctrl_sock, SIOCDIFADDR, &ifrq);
 
 	/* Set the address */
-	(void)memset(&saddr, 0, sizeof saddr);
+	(void)memset(&saddr, 0, sizeof(saddr));
 	saddr.sin_family = AF_INET;
 	saddr.sin_addr.s_addr = s4->s_addr;
-	saddr.sin_len = sizeof saddr;
-	(void)memcpy(&ifrq.ifra_addr, &saddr, sizeof saddr);
+	saddr.sin_len = sizeof(saddr);
+	(void)memcpy(&ifrq.ifra_addr, &saddr, sizeof(saddr));
 
-	(void)memset(&daddr, 0, sizeof daddr);
+	(void)memset(&daddr, 0, sizeof(daddr));
 	daddr.sin_family = AF_INET;
 	daddr.sin_addr.s_addr = s4dest->s_addr;
-	daddr.sin_len = sizeof daddr;
-	(void)memcpy(&ifrq.ifra_broadaddr, &daddr, sizeof daddr);
+	daddr.sin_len = sizeof(daddr);
+	(void)memcpy(&ifrq.ifra_broadaddr, &daddr, sizeof(daddr));
 
 	/* Then set the netmask */
-	(void)memset(&mask, 0, sizeof mask);
+	(void)memset(&mask, 0, sizeof(mask));
 	mask.sin_family = AF_INET;
 	mask.sin_addr.s_addr = bits;
-	mask.sin_len = sizeof mask;
-	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof ifrq.ifra_mask);
+	mask.sin_len = sizeof(mask);
+	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof(ifrq.ifra_mask));
 
 	if (ioctl(dev->ctrl_sock, SIOCAIFADDR, &ifrq) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't set IP address");
@@ -262,8 +262,8 @@ tuntap_sys_set_descr(struct device *dev, const char *descr, size_t len) {
 	struct ifreq ifr;
 	struct ifreq_buffer ifrbuf;
 
-	(void)memset(&ifr, 0, sizeof ifr);
-	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
+	(void)memset(&ifr, 0, sizeof(ifr));
+	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof(ifr.ifr_name));
 
 	ifrbuf.buffer = (void *)descr;
 	ifrbuf.length = len;

--- a/tuntap-unix-freebsd.c
+++ b/tuntap-unix-freebsd.c
@@ -5,6 +5,17 @@
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *
+ * Copyright (c) 2016 Mahdi Mokhtari <mokhi64@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -68,6 +79,8 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 		return -1;
 	}
 
+	dev->mode = mode;
+
 	/* Try to use the given driver or loop throught the avaible ones */
 	fd = -1;
 	if (tun < TUNTAP_ID_MAX) {
@@ -75,7 +88,7 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 		fd = open(name, O_RDWR);
 	} else if (tun == TUNTAP_ID_ANY) {
 		for (tun = 0; tun < TUNTAP_ID_MAX; ++tun) {
-			(void)memset(name, '\0', sizeof name);
+			(void)memset(name, 0, sizeof name);
 			(void)snprintf(name, sizeof name, "/dev/%s%i",
 			    ifname, tun);
 			if ((fd = open(name, O_RDWR)) > 0)
@@ -98,7 +111,7 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 	}
 
 	/* Set the interface name */
-	(void)memset(&ifr, '\0', sizeof ifr);
+	(void)memset(&ifr, 0, sizeof ifr);
 	(void)snprintf(ifr.ifr_name, sizeof ifr.ifr_name, "%s%i", ifname, tun);
 	/* And save it */
 	(void)strlcpy(dev->if_name, ifr.ifr_name, sizeof dev->if_name);
@@ -156,7 +169,7 @@ int
 tuntap_sys_set_hwaddr(struct device *dev, struct ether_addr *eth_addr) {
 	struct ifreq ifr;
 
-	(void)memset(&ifr, '\0', sizeof ifr);
+	(void)memset(&ifr, 0, sizeof ifr);
 	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
 	ifr.ifr_addr.sa_len = ETHER_ADDR_LEN;
 	ifr.ifr_addr.sa_family = AF_LINK;
@@ -169,40 +182,77 @@ tuntap_sys_set_hwaddr(struct device *dev, struct ether_addr *eth_addr) {
 }
 
 int
-tuntap_sys_set_ipv4(struct device *dev, t_tun_in_addr *s4, uint32_t bits) {
-	struct ifreq ifr;
+tuntap_sys_set_ipv4_tap(struct device *dev, t_tun_in_addr *s4, uint32_t bits) {
+	struct ifaliasreq ifrq;
 	struct sockaddr_in mask;
 	struct sockaddr_in addr;
 
-	(void)memset(&ifr, '\0', sizeof ifr);
-	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
+	(void)memset(&ifrq, 0, sizeof ifrq);
+	(void)strlcpy(ifrq.ifra_name, dev->if_name, sizeof ifrq.ifra_name);
 
 	/* Delete previously assigned address */
-	(void)ioctl(dev->ctrl_sock, SIOCDIFADDR, &ifr);
+	(void)ioctl(dev->ctrl_sock, SIOCDIFADDR, &ifrq);
 
 	/* Set the address */
-	(void)memset(&addr, '\0', sizeof addr);
+	(void)memset(&addr, 0, sizeof addr);
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = s4->s_addr;
 	addr.sin_len = sizeof addr;
-	(void)memcpy(&ifr.ifr_addr, &addr, sizeof addr);
+	(void)memcpy(&ifrq.ifra_addr, &addr, sizeof addr);
 
-	if (ioctl(dev->ctrl_sock, SIOCSIFADDR, &ifr) == -1) {
+	/* Then set the netmask */
+	(void)memset(&mask, 0, sizeof mask);
+	mask.sin_family = AF_INET;
+	mask.sin_addr.s_addr = bits;
+	mask.sin_len = sizeof mask;
+	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof ifrq.ifra_mask);
+
+	if (ioctl(dev->ctrl_sock, SIOCAIFADDR, &ifrq) == -1) {
+		tuntap_log(TUNTAP_LOG_ERR, "Can't set IP address/netmask");
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+tuntap_sys_set_ipv4_tun(struct device *dev, t_tun_in_addr *s4, t_tun_in_addr *s4dest, uint32_t bits) {
+	struct ifaliasreq ifrq;
+	struct sockaddr_in mask;
+	struct sockaddr_in saddr;
+	struct sockaddr_in daddr;
+
+	(void)memset(&ifrq, 0, sizeof ifrq);
+	(void)memcpy(ifrq.ifra_name, dev->if_name, sizeof ifrq.ifra_name);
+
+	/* Delete previously assigned address */
+	(void)ioctl(dev->ctrl_sock, SIOCDIFADDR, &ifrq);
+
+	/* Set the address */
+	(void)memset(&saddr, 0, sizeof saddr);
+	saddr.sin_family = AF_INET;
+	saddr.sin_addr.s_addr = s4->s_addr;
+	saddr.sin_len = sizeof saddr;
+	(void)memcpy(&ifrq.ifra_addr, &saddr, sizeof saddr);
+
+	(void)memset(&daddr, 0, sizeof daddr);
+	daddr.sin_family = AF_INET;
+	daddr.sin_addr.s_addr = s4dest->s_addr;
+	daddr.sin_len = sizeof daddr;
+	(void)memcpy(&ifrq.ifra_broadaddr, &daddr, sizeof daddr);
+
+	/* Then set the netmask */
+	(void)memset(&mask, 0, sizeof mask);
+	mask.sin_family = AF_INET;
+	mask.sin_addr.s_addr = bits;
+	mask.sin_len = sizeof mask;
+	(void)memcpy(&ifrq.ifra_mask, &mask, sizeof ifrq.ifra_mask);
+
+	if (ioctl(dev->ctrl_sock, SIOCAIFADDR, &ifrq) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't set IP address");
 		return -1;
 	}
 
-	/* Then set the netmask */
-	(void)memset(&mask, '\0', sizeof mask);
-	mask.sin_family = AF_INET;
-	mask.sin_addr.s_addr = bits;
-	mask.sin_len = sizeof mask;
-	(void)memcpy(&ifr.ifr_addr, &mask, sizeof ifr.ifr_addr);
-
-	if (ioctl(dev->ctrl_sock, SIOCSIFNETMASK, &ifr) == -1) {
-		tuntap_log(TUNTAP_LOG_ERR, "Can't set netmask");
-		return -1;
-	}
 	return 0;
 }
 
@@ -212,7 +262,7 @@ tuntap_sys_set_descr(struct device *dev, const char *descr, size_t len) {
 	struct ifreq ifr;
 	struct ifreq_buffer ifrbuf;
 
-	(void)memset(&ifr, '\0', sizeof ifr);
+	(void)memset(&ifr, 0, sizeof ifr);
 	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
 
 	ifrbuf.buffer = (void *)descr;

--- a/tuntap-unix.c
+++ b/tuntap-unix.c
@@ -5,6 +5,17 @@
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *
+ * Copyright (c) 2016 Mahdi Mokhtari <mokhi64@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR

--- a/tuntap.c
+++ b/tuntap.c
@@ -5,6 +5,17 @@
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *
+ * Copyright (c) 2016 Mahdi Mokhtari <mokhi64@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -41,8 +52,8 @@ tuntap_init(void) {
 	if ((dev = (struct device *)malloc(sizeof(*dev))) == NULL)
 		return NULL;
 
-	(void)memset(dev->if_name, '\0', sizeof dev->if_name);
-	(void)memset(dev->hwaddr, '\0', sizeof dev->hwaddr);
+	(void)memset(dev->if_name, '\0', sizeof(dev->if_name));
+	(void)memset(dev->hwaddr, '\0', sizeof(dev->hwaddr));
 	dev->tun_fd = TUNFD_INVALID_VALUE;
 	dev->ctrl_sock = -1;
 	dev->flags = 0;
@@ -173,8 +184,8 @@ tuntap_set_ip(struct device *dev, ...)
 	 * Destination address parsing: we try IPv4 first and fall back to
 	 * IPv6 if inet_pton return 0
 	 */
-	(void)memset(&sbaddr4, 0, sizeof sbaddr4);
-	(void)memset(&sbaddr6, 0, sizeof sbaddr6);
+	(void)memset(&sbaddr4, 0, sizeof(sbaddr4));
+	(void)memset(&sbaddr6, 0, sizeof(sbaddr6));
 
 	errval = inet_pton(AF_INET, saddr, &(sbaddr4));
 	if (errval == 1) {
@@ -185,7 +196,7 @@ tuntap_set_ip(struct device *dev, ...)
 				tuntap_log(TUNTAP_LOG_ERR, "Invalid parameter 'daddr'");
 				return -1;
 			}
-			(void)memset(&dbaddr4, 0, sizeof dbaddr4);
+			(void)memset(&dbaddr4, 0, sizeof(dbaddr4));
 			(void)inet_pton(AF_INET, daddr, &(dbaddr4));
 			return tuntap_sys_set_ipv4_tun(dev, &sbaddr4, &dbaddr4, mask); 
 		} else
@@ -195,11 +206,11 @@ tuntap_set_ip(struct device *dev, ...)
 		}
 	} else if (errval == 0) {
 #if !defined(FreeBSD) /* No IPV6 tests YET */
-		if (inet_pton(AF_INET6, addr, &(baddr6)) == -1) {
+		if (inet_pton(AF_INET6, saddr, &(sbaddr6)) == -1) {
 			tuntap_log(TUNTAP_LOG_ERR, "Invalid parameters");
 			return -1;
 		}
-		return tuntap_sys_set_ipv6(dev, &baddr6, mask);
+		return tuntap_sys_set_ipv6(dev, &sbaddr6, mask);
 	} else if (errval == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Invalid parameters");
 		return -1;

--- a/tuntap.c
+++ b/tuntap.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <ctype.h>
 
+#include <stdarg.h>
+
 #include "tuntap.h"
 
 struct device *
@@ -65,8 +67,9 @@ tuntap_version(void) {
     return TUNTAP_VERSION;
 }
 
+#if !defined(FreeBSD)
 int
-tuntap_set_ip(struct device *dev, const char *addr, int netmask) {
+tuntap_set_ip_old(struct device *dev, const char *addr, int netmask) {
 	t_tun_in_addr baddr4;
 	t_tun_in6_addr baddr6;
 	uint32_t mask;
@@ -116,4 +119,94 @@ tuntap_set_ip(struct device *dev, const char *addr, int netmask) {
 
 	/* NOTREACHED */
 	return -1;
+}
+#endif
+
+int
+tuntap_set_ip(struct device *dev, ...)
+{
+	va_list vl;
+	char *saddr;
+	char *daddr;
+	int netmask;
+	t_tun_in_addr sbaddr4;
+	t_tun_in_addr dbaddr4;
+	t_tun_in6_addr sbaddr6;
+	t_tun_in6_addr dbaddr6;
+	uint32_t mask;
+	int errval;
+
+	saddr = daddr = NULL;
+	netmask = -1;
+
+	va_start(vl, dev);
+	saddr = va_arg(vl, char *);
+	netmask = va_arg(vl, int);
+#if defined(FreeBSD)
+	if (dev->mode == TUNTAP_MODE_TUNNEL)
+		daddr = va_arg(vl, char *);
+#endif
+	va_end(vl);
+
+		/* Only accept started device */
+	if (dev->tun_fd == TUNFD_INVALID_VALUE) {
+		tuntap_log(TUNTAP_LOG_NOTICE, "Device is not started");
+		return 0;
+	}
+
+	if (saddr == NULL) {
+		tuntap_log(TUNTAP_LOG_ERR, "Invalid parameter 'saddr'");
+		return -1;
+	}
+
+	if (netmask < 0 || netmask > 128) {
+		tuntap_log(TUNTAP_LOG_ERR, "Invalid parameter 'netmask'");
+		return -1;
+	}
+
+	/* Netmask */
+	mask = ~0;
+	mask = ~(mask >> netmask);
+	mask = htonl(mask);
+
+	/*
+	 * Destination address parsing: we try IPv4 first and fall back to
+	 * IPv6 if inet_pton return 0
+	 */
+	(void)memset(&sbaddr4, 0, sizeof sbaddr4);
+	(void)memset(&sbaddr6, 0, sizeof sbaddr6);
+
+	errval = inet_pton(AF_INET, saddr, &(sbaddr4));
+	if (errval == 1) {
+#if defined(FreeBSD)
+#define tuntap_sys_set_ipv4 tuntap_sys_set_ipv4_tap
+		if (dev->mode == TUNTAP_MODE_TUNNEL) {
+			if (daddr == NULL) {
+				tuntap_log(TUNTAP_LOG_ERR, "Invalid parameter 'daddr'");
+				return -1;
+			}
+			(void)memset(&dbaddr4, 0, sizeof dbaddr4);
+			(void)inet_pton(AF_INET, daddr, &(dbaddr4));
+			return tuntap_sys_set_ipv4_tun(dev, &sbaddr4, &dbaddr4, mask); 
+		} else
+#endif
+		{
+			return tuntap_sys_set_ipv4(dev, &sbaddr4, mask);
+		}
+	} else if (errval == 0) {
+#if !defined(FreeBSD) /* No IPV6 tests YET */
+		if (inet_pton(AF_INET6, addr, &(baddr6)) == -1) {
+			tuntap_log(TUNTAP_LOG_ERR, "Invalid parameters");
+			return -1;
+		}
+		return tuntap_sys_set_ipv6(dev, &baddr6, mask);
+	} else if (errval == -1) {
+		tuntap_log(TUNTAP_LOG_ERR, "Invalid parameters");
+		return -1;
+#endif
+	}
+
+	/* NOTREACHED */
+	return -1;
+
 }

--- a/tuntap.h
+++ b/tuntap.h
@@ -5,6 +5,17 @@
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *
+ * Copyright (c) 2016 Mahdi Mokhtari <mokhi64@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -135,6 +146,9 @@ struct device {
 	int				flags;     /* ifr.ifr_flags on Unix */
 	unsigned char	hwaddr[ETHER_ADDR_LEN];
 	char			if_name[IF_NAMESIZE];
+#if defined(FreeBSD)
+	int				mode;
+#endif
 };
 
 /* User definable log callback */
@@ -156,7 +170,13 @@ TUNTAP_EXPORT int		 tuntap_up(struct device *);
 TUNTAP_EXPORT int		 tuntap_down(struct device *);
 TUNTAP_EXPORT int		 tuntap_get_mtu(struct device *);
 TUNTAP_EXPORT int		 tuntap_set_mtu(struct device *, int);
-TUNTAP_EXPORT int		 tuntap_set_ip(struct device *, const char *, int);
+/*
+ * It's impossible to set single IP for `tun` devices on FreeBSD .
+ * FreeBSD's `tun` interface needs 2 IP addresses.
+ * So a new (and backward compatible) version of tuntap_set_ip() is implemented.
+ */
+TUNTAP_EXPORT int		 tuntap_set_ip(struct device *, ...);
+/*TUNTAP_EXPORT int		 tuntap_set_ip_old(struct device *, const char *, int);*/
 TUNTAP_EXPORT int		 tuntap_read(struct device *, void *, size_t);
 TUNTAP_EXPORT int		 tuntap_write(struct device *, void *, size_t);
 TUNTAP_EXPORT int		 tuntap_get_readable(struct device *);
@@ -173,6 +193,10 @@ void		 tuntap_log_chksum(void *, int);
 int		 tuntap_sys_start(struct device *, int, int);
 void	 tuntap_sys_destroy(struct device *);
 int		 tuntap_sys_set_hwaddr(struct device *, struct ether_addr *);
+#if defined(FreeBSD)
+int		 tuntap_sys_set_ipv4_tap(struct device *, t_tun_in_addr *, uint32_t);
+int		 tuntap_sys_set_ipv4_tun(struct device *dev, t_tun_in_addr *s4, t_tun_in_addr *s4dest, uint32_t bits);
+#endif
 int		 tuntap_sys_set_ipv4(struct device *, t_tun_in_addr *, uint32_t);
 int		 tuntap_sys_set_ipv6(struct device *, t_tun_in6_addr *, uint32_t);
 int		 tuntap_sys_set_ifname(struct device *, const char *, size_t);


### PR DESCRIPTION
FreeBSD's _**tun**_ interface needs _**two IP**_ addresses.
According documents (like [This](https://wiki.strongswan.org/issues/566) and also official docs) `SIOCSIFADDR` command is deprecated.
So i rewrote some parts of it in a backward compatible manner.
According the final test results you can now update the README and add FreeBSD as completely supported platform. 