### PR TITLE
Add libtun++ module to `make install` command

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -21,3 +21,10 @@ target_link_libraries(tuntap++ tuntap)
 
 target_link_libraries(tuntap++-static tuntap)
 
+if(UNIX)
+	if(ENABLE_CXX)
+		install(TARGETS tuntap++ DESTINATION lib)
+		install(FILES ./bindings/cpp/tuntap++.hh DESTINATION include)
+		install(TARGETS tuntap++-static DESTINATION lib)
+	endif(ENABLE_CXX)
+endif(UNIX)


### PR DESCRIPTION
Hi,
we've added the missing installation of `tuntap++.hh` and `tuntap++.so` to the `make install` command with the ENABLE_CXX flag.