### PR TITLE
Add compiler flag '-std=c++11' if ENABLE_CXX is on

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # libtuntap C++ binding CMakeLists.txt
 # ====================================
 
+set(CMAKE_CXX_STANDARD 11)
+
 include_directories(
     "${CMAKE_CURRENT_SOURCE_DIR}"/bindings/cpp
 )


### PR DESCRIPTION
Hi, 

using the compiler `g++ (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609`, the `make` command failed. To fix it I have added the flag `-std=c++11` if the cmake flag `ENABLE_CXX` is on.