### PR TITLE
Add support for musl-libc runtime library

### DIFF
--- a/if_tun.h
+++ b/if_tun.h
@@ -1,0 +1,75 @@
+/* stripped-up version of linux header for libtuntap */
+/*
+ *  Universal TUN/TAP device driver.
+ *  Copyright (C) 1999-2000 Maxim Krasnyansky <max_mk@yahoo.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+#ifndef LIBTUNTAP__IF_TUN_H
+#define LIBTUNTAP__IF_TUN_H
+/* Read queue size */
+#define TUN_READQ_SIZE	500
+/* TUN device type flags: deprecated. Use IFF_TUN/IFF_TAP instead. */
+#define TUN_TUN_DEV 	IFF_TUN
+#define TUN_TAP_DEV	IFF_TAP
+#define TUN_TYPE_MASK   0x000f
+/* Ioctl defines */
+#define TUNSETNOCSUM  _IOW('T', 200, int)
+#define TUNSETDEBUG   _IOW('T', 201, int)
+#define TUNSETIFF     _IOW('T', 202, int)
+#define TUNSETPERSIST _IOW('T', 203, int)
+#define TUNSETOWNER   _IOW('T', 204, int)
+#define TUNSETLINK    _IOW('T', 205, int)
+#define TUNSETGROUP   _IOW('T', 206, int)
+#define TUNGETFEATURES _IOR('T', 207, unsigned int)
+#define TUNSETOFFLOAD  _IOW('T', 208, unsigned int)
+#define TUNSETTXFILTER _IOW('T', 209, unsigned int)
+#define TUNGETIFF      _IOR('T', 210, unsigned int)
+#define TUNGETSNDBUF   _IOR('T', 211, int)
+#define TUNSETSNDBUF   _IOW('T', 212, int)
+#define TUNATTACHFILTER _IOW('T', 213, struct sock_fprog)
+#define TUNDETACHFILTER _IOW('T', 214, struct sock_fprog)
+#define TUNGETVNETHDRSZ _IOR('T', 215, int)
+#define TUNSETVNETHDRSZ _IOW('T', 216, int)
+#define TUNSETQUEUE  _IOW('T', 217, int)
+#define TUNSETIFINDEX	_IOW('T', 218, unsigned int)
+#define TUNGETFILTER _IOR('T', 219, struct sock_fprog)
+#define TUNSETVNETLE _IOW('T', 220, int)
+#define TUNGETVNETLE _IOR('T', 221, int)
+/* The TUNSETVNETBE and TUNGETVNETBE ioctls are for cross-endian support on
+ * little-endian hosts. Not all kernel configurations support them, but all
+ * configurations that support SET also support GET.
+ */
+#define TUNSETVNETBE _IOW('T', 222, int)
+#define TUNGETVNETBE _IOR('T', 223, int)
+/* TUNSETIFF ifr flags */
+#define IFF_TUN		0x0001
+#define IFF_TAP		0x0002
+#define IFF_NO_PI	0x1000
+/* This flag has no real effect */
+#define IFF_ONE_QUEUE	0x2000
+#define IFF_VNET_HDR	0x4000
+#define IFF_TUN_EXCL	0x8000
+#define IFF_MULTI_QUEUE 0x0100
+#define IFF_ATTACH_QUEUE 0x0200
+#define IFF_DETACH_QUEUE 0x0400
+/* read-only flag */
+#define IFF_PERSIST	0x0800
+#define IFF_NOFILTER	0x1000
+/* Socket options */
+#define TUN_TX_TIMESTAMP 1
+/* Features for GSO (TUNSETOFFLOAD). */
+#define TUN_F_CSUM	0x01	/* You can hand me unchecksummed packets. */
+#define TUN_F_TSO4	0x02	/* I can handle TSO for IPv4 packets */
+#define TUN_F_TSO6	0x04	/* I can handle TSO for IPv6 packets */
+#define TUN_F_TSO_ECN	0x08	/* I can handle TSO with ECN bits. */
+#define TUN_F_UFO	0x10	/* I can handle UFO packets */
+#endif /* __IF_TUN_H */

--- a/private.h
+++ b/private.h
@@ -23,11 +23,7 @@
 #endif
 
 #if !defined Windows /* Unix :) */
-# if defined Linux
-#  include <linux/if.h>
-# else
-#  include <net/if.h>
-# endif
+# include <net/if.h>
 # include <netinet/in.h>
 # include <netinet/if_ether.h>
 #endif

--- a/tuntap-unix-linux.c
+++ b/tuntap-unix-linux.c
@@ -20,8 +20,6 @@
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <linux/if.h>
-#include <linux/if_tun.h>
 #include <netinet/if_ether.h>
 #include <net/if_arp.h>
 
@@ -32,6 +30,8 @@
 #include <string.h>
 #include <unistd.h>
 
+// Stripped down version of linux/if_tun.h
+#include "if_tun.h"
 #include "tuntap.h"
 #include "private.h"
 


### PR DESCRIPTION
Hello,
we were trying to compile our application inside an Alpine Linux Docker container and we noticed include errors since Alpine doesn't use GLIBC, but it uses Musl-libc:
```
bash-4.4# make
Scanning dependencies of target tuntap
[  7%] Building C object CMakeFiles/tuntap.dir/tuntap.c.o
[ 14%] Building C object CMakeFiles/tuntap.dir/tuntap_log.c.o
[ 21%] Building C object CMakeFiles/tuntap.dir/tuntap-unix.c.o
[ 28%] Building C object CMakeFiles/tuntap.dir/tuntap-unix-linux.c.o
In file included from /libtuntap/tuntap-unix-linux.c:25:0:
/usr/include/netinet/if_ether.h:104:8: error: redefinition of 'struct ethhdr'
 struct ethhdr {
        ^~~~~~
In file included from /usr/include/linux/if_tun.h:20:0,
                 from /libtuntap/tuntap-unix-linux.c:24:
/usr/include/linux/if_ether.h:140:8: note: originally defined here
 struct ethhdr {
        ^~~~~~
make[2]: *** [CMakeFiles/tuntap.dir/build.make:102: CMakeFiles/tuntap.dir/tuntap-unix-linux.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/tuntap.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```
The reason of the error is explained here: https://wiki.musl-libc.org/faq.html#Q:-Why-am-I-getting-
I've fixed them adding a stripped down version of `if_tun.h` to the project. I've taken the solution from here: https://github.com/stsp/dosemu2/issues/530

This solution works on Alpine Linux and on systems using gnu libc with this version:
```
[dpolonio@davmark ~]$ /usr/lib/libc.so.6 
GNU C Library (GNU libc) stable release version 2.28.
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.
Compiled by GNU CC version 8.2.0.
libc ABIs: UNIQUE IFUNC ABSOLUTE
For bug reporting instructions, please see:
<https://bugs.archlinux.org/>.
```

Hope it helps!
Cheers