### PR TITLE
Fix persistency related tests on Darwin

### DIFF
--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -46,6 +46,14 @@ if(NetBSD)
   set_tests_properties(tuntap.test39 PROPERTIES WILL_FAIL true)
 endif()
 
+# Persistence is not implemented on Darwin
+if(Darwin)
+  set_tests_properties(test33 PROPERTIES WILL_FAIL true)
+  set_tests_properties(test34 PROPERTIES WILL_FAIL true)
+  set_tests_properties(test35 PROPERTIES WILL_FAIL true)
+  set_tests_properties(test36 PROPERTIES WILL_FAIL true)
+endif()
+
 # Only Linux has a tuntap_set_ifname() implemented
 if(NOT Linux)
   set_tests_properties(tuntap.test41 PROPERTIES WILL_FAIL true)

--- a/regress/CMakeLists.txt
+++ b/regress/CMakeLists.txt
@@ -27,7 +27,6 @@ foreach(SOURCE_FILE ${ALL_SH_TESTS})
       add_executable(${HELPER_NAME} ${TEST_SRC_PATH}/${HELPER_NAME}.c)
       target_link_libraries(${HELPER_NAME} tuntap)
   endif()
-
   add_test(NAME tuntap.${TEST_NAME}
            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.sh)
 endforeach(SOURCE_FILE)
@@ -48,10 +47,10 @@ endif()
 
 # Persistence is not implemented on Darwin
 if(Darwin)
-  set_tests_properties(test33 PROPERTIES WILL_FAIL true)
-  set_tests_properties(test34 PROPERTIES WILL_FAIL true)
-  set_tests_properties(test35 PROPERTIES WILL_FAIL true)
-  set_tests_properties(test36 PROPERTIES WILL_FAIL true)
+  set_tests_properties(tuntap.test33 PROPERTIES WILL_FAIL true)
+  set_tests_properties(tuntap.test34 PROPERTIES WILL_FAIL true)
+  set_tests_properties(tuntap.test35 PROPERTIES WILL_FAIL true)
+  set_tests_properties(tuntap.test36 PROPERTIES WILL_FAIL true)
 endif()
 
 # Only Linux has a tuntap_set_ifname() implemented
@@ -90,4 +89,3 @@ if (Windows)
   set_tests_properties(tuntap.test26 PROPERTIES WILL_FAIL true)
   set_tests_properties(tuntap.test40 PROPERTIES WILL_FAIL true)
 endif()
-

--- a/tuntap-unix-darwin.c
+++ b/tuntap-unix-darwin.c
@@ -36,11 +36,6 @@
 #include "tuntap.h"
 #include "private.h"
 
-static int
-tuntap_sys_create_dev(struct device *dev, int tun) {
-	return -1;
-}
-
 int
 tuntap_sys_start(struct device *dev, int mode, int tun) {
 	struct ifreq ifr;
@@ -53,8 +48,9 @@ tuntap_sys_start(struct device *dev, int mode, int tun) {
 
 	/* Force creation of the driver if needed or let it resilient */
 	if (mode & TUNTAP_MODE_PERSIST) {
-		mode &= ~TUNTAP_MODE_PERSIST;
-		/* TODO: Call tuntap_sys_create_dev() */
+		tuntap_log(TUNTAP_LOG_NOTICE,
+		    "Your system does not support persistent device");
+		return -1;
 	}
 
         /* Set the mode: tun or tap */


### PR DESCRIPTION
Persistent devices are not  implemented for Darwin so tell it directly to the user instead of failing to comply.

Can you try one last time @ntnmrndn ?

Thanks.