### PR TITLE
tuntap_get_ifname should not return static sized buffer as null terminated char *

### DIFF
--- a/private.h
+++ b/private.h
@@ -92,7 +92,7 @@ struct device {
 	int		ctrl_sock;
 	int		flags;     /* ifr.ifr_flags on Unix */
 	unsigned char	hwaddr[ETHER_ADDR_LEN];
-	char		if_name[IF_NAMESIZE];
+	char		if_name[IF_NAMESIZE + 1];
 };
 
 /*


### PR DESCRIPTION
tuntap_get_ifname may return a `char *` that is not null terminated which may cause buffer overflows in codebases in which the interface name is equal to `IFNAMSIZ` and assume its return value is null terminated. correct this and make api a bit more sane for that case.