### PR TITLE
Fix small logger issues

### DIFF
--- a/private.h
+++ b/private.h
@@ -105,7 +105,7 @@ struct device {
 # endif
 
 /* Internal log facilities */
-t_tuntap_log tuntap_log;
+extern t_tuntap_log tuntap_log;
 void	 tuntap_log_default(int, const char *);
 void	 tuntap_log_hexdump(void *, size_t);
 void	 tuntap_log_chksum(void *, int);

--- a/tuntap-unix.c
+++ b/tuntap-unix.c
@@ -34,6 +34,7 @@
 # include <netinet/if_ether.h>
 #endif
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -268,7 +269,9 @@ tuntap_read(struct device *dev, void *buf, size_t size) {
 
 	n = read(dev->tun_fd, buf, size);
 	if (n == -1) {
-		tuntap_log(TUNTAP_LOG_WARN, "Can't to read from device");
+        if (errno != EAGAIN) {
+		    tuntap_log(TUNTAP_LOG_WARN, "Can't to read from device");
+        }
 		return -1;
 	}
 	return n;

--- a/tuntap_log.c
+++ b/tuntap_log.c
@@ -79,8 +79,8 @@ tuntap_log_hexdump(void *data, size_t size) {
 	for (n = 1; n <= size; n++) {
 		if (n % 16 == 1) {
 			/* store address for this line */
-			snprintf(addrstr, sizeof(addrstr), "%.4llx",
-			    ((uintptr_t)p - (uintptr_t)data) );
+			snprintf(addrstr, sizeof(addrstr), "%.4zx",
+			    (p - (unsigned char *)data) );
 		}
 
 		c = *p;

--- a/tuntap_log.c
+++ b/tuntap_log.c
@@ -26,6 +26,8 @@
 #include "tuntap.h"
 #include "private.h"
 
+t_tuntap_log tuntap_log = NULL;
+
 void
 tuntap_log_set_cb(t_tuntap_log cb) {
 	if (cb == NULL)


### PR DESCRIPTION
This small PR fixes a two simple issues:

1. Use 'z' for ptrdiff_t *printf spec
2. Avoids multiple instances of tuntap_log
3. Don't warn if read() returns EAGAIN - that's OK for non-blocking read()

Hopefully you'll find them useful and merge upstream.