### PR TITLE
C++ bindings

### DIFF
--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -49,7 +49,9 @@ tuntap::name() const
 void
 tuntap::name(std::string const &s)
 {
-    tuntap_set_ifname(_dev, s.c_str());
+    if (tuntap_set_ifname(_dev, s.c_str())) {
+        throw std::runtime_error("Failed to set ifname");
+    }
 }
 
 t_tun

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -12,10 +12,10 @@ tuntap::tuntap(int mode, int id)
     if (mode != TUNTAP_MODE_ETHERNET && mode != TUNTAP_MODE_TUNNEL) {
         throw std::invalid_argument("Unknown tuntap mode");
     }
-    if (id > TUNTAP_ID_MAX) {
-        throw std::invalid_argument("Tunnel ID too big");
+    if (id < 0 || id > TUNTAP_ID_MAX) {
+        throw std::invalid_argument("Tunnel ID is invalid");
     }
-    if (tuntap_start(_dev, mode, id) == -1) {
+    if (tuntap_start(_dev, mode, id)) {
         throw std::runtime_error("tuntap_start failed");
     }
 }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -85,7 +85,9 @@ tuntap::mtu() const
 void
 tuntap::mtu(int m)
 {
-    tuntap_set_mtu(_dev, m);
+    if (tuntap_set_mtu(_dev, m)) {
+        throw std::runtime_error("Failed to set mtu for tuntap device");
+    }
 }
 
 void

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -27,21 +27,21 @@ tuntap::~tuntap()
     }
 }
 
-tuntap::tuntap(tuntap &&t)
+tuntap::tuntap(tuntap &&t) noexcept
     : _dev(nullptr)
 {
     std::swap(t._dev, this->_dev);
 }
 
 void
-tuntap::release()
+tuntap::release() noexcept
 {
     tuntap_release(_dev);
     _started = false;
 }
 
 std::string
-tuntap::name() const
+tuntap::name() const noexcept
 {
     return std::string(tuntap_get_ifname(_dev));
 }
@@ -55,7 +55,7 @@ tuntap::name(std::string const &s)
 }
 
 t_tun
-tuntap::native_handle() const
+tuntap::native_handle() const noexcept
 {
     return tuntap_get_fd(this->_dev);
 }
@@ -77,7 +77,7 @@ tuntap::down()
 }
 
 int
-tuntap::mtu() const
+tuntap::mtu() const noexcept
 {
     return tuntap_get_mtu(_dev);
 }
@@ -105,13 +105,13 @@ tuntap::ip(std::string const &s, int netmask)
 }
 
 int
-tuntap::read(void *buf, size_t len)
+tuntap::read(void *buf, size_t len) noexcept
 {
 	return tuntap_read(_dev, buf, len);
 }
 
 int
-tuntap::write(void *buf, size_t len)
+tuntap::write(void *buf, size_t len) noexcept
 {
 	return tuntap_write(_dev, buf, len);
 }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -43,7 +43,7 @@ tuntap::release()
 std::string
 tuntap::name() const
 {
-    return tuntap_get_ifname(_dev);
+    return std::string(tuntap_get_ifname(_dev));
 }
 
 void

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -1,9 +1,5 @@
 #include "tuntap++.hh"
 
-#include <string>
-#include <algorithm>
-#include <stdexcept>
-
 namespace tuntap {
 
 tuntap::tuntap(int mode, int id)
@@ -97,13 +93,13 @@ tuntap::ip(std::string const &s, int netmask)
 }
 
 int
-tuntap::read(void *buf, size_t len) noexcept
+tuntap::read(void *buf, std::size_t len) noexcept
 {
 	return ::tuntap_read(_dev.get(), buf, len);
 }
 
 int
-tuntap::write(void *buf, size_t len) noexcept
+tuntap::write(void *buf, std::size_t len) noexcept
 {
 	return ::tuntap_write(_dev.get(), buf, len);
 }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -7,7 +7,7 @@
 namespace tuntap {
 
 tuntap::tuntap(int mode, int id)
-    : _dev{tuntap_init()}, _started{true}
+    : _dev{::tuntap_init()}, _started{true}
 {
     if (mode != TUNTAP_MODE_ETHERNET && mode != TUNTAP_MODE_TUNNEL) {
         throw std::invalid_argument("Unknown tuntap mode");
@@ -15,7 +15,7 @@ tuntap::tuntap(int mode, int id)
     if (id < 0 || id > TUNTAP_ID_MAX) {
         throw std::invalid_argument("Tunnel ID is invalid");
     }
-    if (tuntap_start(_dev, mode, id)) {
+    if (::tuntap_start(_dev, mode, id)) {
         throw std::runtime_error("tuntap_start failed");
     }
 }
@@ -23,7 +23,7 @@ tuntap::tuntap(int mode, int id)
 tuntap::~tuntap()
 {
     if (_started) {
-        tuntap_destroy(_dev);
+        ::tuntap_destroy(_dev);
     }
 }
 
@@ -36,20 +36,20 @@ tuntap::tuntap(tuntap &&t) noexcept
 void
 tuntap::release() noexcept
 {
-    tuntap_release(_dev);
+    ::tuntap_release(_dev);
     _started = false;
 }
 
 std::string
 tuntap::name() const noexcept
 {
-    return std::string(tuntap_get_ifname(_dev));
+    return std::string(::tuntap_get_ifname(_dev));
 }
 
 void
 tuntap::name(std::string const &s)
 {
-    if (tuntap_set_ifname(_dev, s.c_str())) {
+    if (::tuntap_set_ifname(_dev, s.c_str())) {
         throw std::runtime_error("Failed to set ifname");
     }
 }
@@ -57,13 +57,13 @@ tuntap::name(std::string const &s)
 t_tun
 tuntap::native_handle() const noexcept
 {
-    return tuntap_get_fd(this->_dev);
+    return ::tuntap_get_fd(this->_dev);
 }
 
 void
 tuntap::up()
 {
-    if (tuntap_up(_dev)) {
+    if (::tuntap_up(_dev)) {
         throw std::runtime_error("Failed to bring up tuntap device");
     }
 }
@@ -71,7 +71,7 @@ tuntap::up()
 void
 tuntap::down()
 {
-    if (tuntap_down(_dev)) {
+    if (::tuntap_down(_dev)) {
         throw std::runtime_error("Failed to bring down tuntap device");
     }
 }
@@ -79,7 +79,7 @@ tuntap::down()
 int
 tuntap::mtu() const noexcept
 {
-    return tuntap_get_mtu(_dev);
+    return ::tuntap_get_mtu(_dev);
 }
 
 void
@@ -88,7 +88,7 @@ tuntap::mtu(int m)
     if (m < 1 || m > 65535) {
         throw std::invalid_argument("Invalid mtu");
     }
-    if (tuntap_set_mtu(_dev, m)) {
+    if (::tuntap_set_mtu(_dev, m)) {
         throw std::runtime_error("Failed to set mtu for tuntap device");
     }
 }
@@ -99,7 +99,7 @@ tuntap::ip(std::string const &s, int netmask)
     if (netmask > 128) {
         throw std::invalid_argument("Invalid netmask");
     }
-    if (tuntap_set_ip(_dev, s.c_str(), netmask)) {
+    if (::tuntap_set_ip(_dev, s.c_str(), netmask)) {
         throw std::runtime_error("Failed to set ip for tuntap device");
     }
 }
@@ -107,19 +107,19 @@ tuntap::ip(std::string const &s, int netmask)
 int
 tuntap::read(void *buf, size_t len) noexcept
 {
-	return tuntap_read(_dev, buf, len);
+	return ::tuntap_read(_dev, buf, len);
 }
 
 int
 tuntap::write(void *buf, size_t len) noexcept
 {
-	return tuntap_write(_dev, buf, len);
+	return ::tuntap_write(_dev, buf, len);
 }
 
 void
 tuntap::nonblocking(bool b)
 {
-    if (tuntap_set_nonblocking(_dev, int(b))) {
+    if (::tuntap_set_nonblocking(_dev, int(b))) {
         throw std::runtime_error("Failed to change non-blocking state for tuntap device");
     }
 }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -7,7 +7,7 @@
 namespace tuntap {
 
 tuntap::tuntap(int mode, int id)
-    : _dev{::tuntap_init()}, _started{true}
+    : _dev{::tuntap_init()}
 {
     if (mode != TUNTAP_MODE_ETHERNET && mode != TUNTAP_MODE_TUNNEL) {
         throw std::invalid_argument("Unknown tuntap mode");
@@ -15,41 +15,33 @@ tuntap::tuntap(int mode, int id)
     if (id < 0 || id > TUNTAP_ID_MAX) {
         throw std::invalid_argument("Tunnel ID is invalid");
     }
-    if (::tuntap_start(_dev, mode, id)) {
+    if (::tuntap_start(_dev.get(), mode, id)) {
         throw std::runtime_error("tuntap_start failed");
     }
 }
 
-tuntap::~tuntap()
-{
-    if (_started) {
-        ::tuntap_destroy(_dev);
-    }
-}
-
 tuntap::tuntap(tuntap &&t) noexcept
-    : _dev(nullptr)
+    : _dev()
 {
-    std::swap(t._dev, this->_dev);
+    t._dev.swap(this->_dev);
 }
 
 void
 tuntap::release() noexcept
 {
-    ::tuntap_release(_dev);
-    _started = false;
+    _dev.release();
 }
 
 std::string
 tuntap::name() const noexcept
 {
-    return std::string(::tuntap_get_ifname(_dev));
+    return std::string(::tuntap_get_ifname(_dev.get()));
 }
 
 void
 tuntap::name(std::string const &s)
 {
-    if (::tuntap_set_ifname(_dev, s.c_str())) {
+    if (::tuntap_set_ifname(_dev.get(), s.c_str())) {
         throw std::runtime_error("Failed to set ifname");
     }
 }
@@ -57,13 +49,13 @@ tuntap::name(std::string const &s)
 t_tun
 tuntap::native_handle() const noexcept
 {
-    return ::tuntap_get_fd(this->_dev);
+    return ::tuntap_get_fd(_dev.get());
 }
 
 void
 tuntap::up()
 {
-    if (::tuntap_up(_dev)) {
+    if (::tuntap_up(_dev.get())) {
         throw std::runtime_error("Failed to bring up tuntap device");
     }
 }
@@ -71,7 +63,7 @@ tuntap::up()
 void
 tuntap::down()
 {
-    if (::tuntap_down(_dev)) {
+    if (::tuntap_down(_dev.get())) {
         throw std::runtime_error("Failed to bring down tuntap device");
     }
 }
@@ -79,7 +71,7 @@ tuntap::down()
 int
 tuntap::mtu() const noexcept
 {
-    return ::tuntap_get_mtu(_dev);
+    return ::tuntap_get_mtu(_dev.get());
 }
 
 void
@@ -88,7 +80,7 @@ tuntap::mtu(int m)
     if (m < 1 || m > 65535) {
         throw std::invalid_argument("Invalid mtu");
     }
-    if (::tuntap_set_mtu(_dev, m)) {
+    if (::tuntap_set_mtu(_dev.get(), m)) {
         throw std::runtime_error("Failed to set mtu for tuntap device");
     }
 }
@@ -99,7 +91,7 @@ tuntap::ip(std::string const &s, int netmask)
     if (netmask > 128) {
         throw std::invalid_argument("Invalid netmask");
     }
-    if (::tuntap_set_ip(_dev, s.c_str(), netmask)) {
+    if (::tuntap_set_ip(_dev.get(), s.c_str(), netmask)) {
         throw std::runtime_error("Failed to set ip for tuntap device");
     }
 }
@@ -107,19 +99,19 @@ tuntap::ip(std::string const &s, int netmask)
 int
 tuntap::read(void *buf, size_t len) noexcept
 {
-	return ::tuntap_read(_dev, buf, len);
+	return ::tuntap_read(_dev.get(), buf, len);
 }
 
 int
 tuntap::write(void *buf, size_t len) noexcept
 {
-	return ::tuntap_write(_dev, buf, len);
+	return ::tuntap_write(_dev.get(), buf, len);
 }
 
 void
 tuntap::nonblocking(bool b)
 {
-    if (::tuntap_set_nonblocking(_dev, int(b))) {
+    if (::tuntap_set_nonblocking(_dev.get(), static_cast<int>(b))) {
         throw std::runtime_error("Failed to change non-blocking state for tuntap device");
     }
 }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -71,7 +71,9 @@ tuntap::up()
 void
 tuntap::down()
 {
-    tuntap_down(_dev);
+    if (tuntap_down(_dev)) {
+        throw std::runtime_error("Failed to bring down tuntap device");
+    }
 }
 
 int

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -113,7 +113,9 @@ tuntap::write(void *buf, size_t len)
 void
 tuntap::nonblocking(bool b)
 {
-    tuntap_set_nonblocking(_dev, int(b));
+    if (tuntap_set_nonblocking(_dev, int(b))) {
+        throw std::runtime_error("Failed to change non-blocking state for tuntap device");
+    }
 }
 
 } /* tuntap */

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -63,7 +63,9 @@ tuntap::native_handle() const
 void
 tuntap::up()
 {
-    tuntap_up(_dev);
+    if (tuntap_up(_dev)) {
+        throw std::runtime_error("Failed to bring up tuntap device");
+    }
 }
 
 void

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -85,6 +85,9 @@ tuntap::mtu() const
 void
 tuntap::mtu(int m)
 {
+    if (m < 1 || m > 65535) {
+        throw std::invalid_argument("Invalid mtu");
+    }
     if (tuntap_set_mtu(_dev, m)) {
         throw std::runtime_error("Failed to set mtu for tuntap device");
     }
@@ -93,6 +96,9 @@ tuntap::mtu(int m)
 void
 tuntap::ip(std::string const &s, int netmask)
 {
+    if (netmask > 128) {
+        throw std::invalid_argument("Invalid netmask");
+    }
     if (tuntap_set_ip(_dev, s.c_str(), netmask)) {
         throw std::runtime_error("Failed to set ip for tuntap device");
     }

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -93,7 +93,9 @@ tuntap::mtu(int m)
 void
 tuntap::ip(std::string const &s, int netmask)
 {
-    tuntap_set_ip(_dev, s.c_str(), netmask);
+    if (tuntap_set_ip(_dev, s.c_str(), netmask)) {
+        throw std::runtime_error("Failed to set ip for tuntap device");
+    }
 }
 
 int

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -6,203 +6,102 @@
 
 namespace tuntap {
 
-tun::tun()
+tuntap::tuntap(int mode, int id)
     : _dev{tuntap_init()}, _started{true}
 {
-    if (tuntap_start(_dev, TUNTAP_MODE_TUNNEL, TUNTAP_ID_ANY) == -1) {
+    if (mode != TUNTAP_MODE_ETHERNET && mode != TUNTAP_MODE_TUNNEL) {
+        throw std::invalid_argument("Unknown tuntap mode");
+    }
+    if (id > TUNTAP_ID_MAX) {
+        throw std::invalid_argument("Tunnel ID too big");
+    }
+    if (tuntap_start(_dev, mode, id) == -1) {
         throw std::runtime_error("tuntap_start failed");
     }
 }
 
-tun::~tun()
+tuntap::~tuntap()
 {
     if (_started) {
         tuntap_destroy(_dev);
     }
 }
 
-tun::tun(tun &&t)
+tuntap::tuntap(tuntap &&t)
     : _dev(nullptr)
 {
     std::swap(t._dev, this->_dev);
 }
 
 void
-tun::release()
+tuntap::release()
 {
     tuntap_release(_dev);
     _started = false;
 }
 
 std::string
-tun::name() const
+tuntap::name() const
 {
     return tuntap_get_ifname(_dev);
 }
 
 void
-tun::name(std::string const &s)
+tuntap::name(std::string const &s)
 {
     tuntap_set_ifname(_dev, s.c_str());
 }
 
 t_tun
-tun::native_handle() const
+tuntap::native_handle() const
 {
     return tuntap_get_fd(this->_dev);
 }
 
 void
-tun::up()
+tuntap::up()
 {
     tuntap_up(_dev);
 }
 
 void
-tun::down()
+tuntap::down()
 {
     tuntap_down(_dev);
 }
 
 int
-tun::mtu() const
+tuntap::mtu() const
 {
     return tuntap_get_mtu(_dev);
 }
 
 void
-tun::mtu(int m)
+tuntap::mtu(int m)
 {
     tuntap_set_mtu(_dev, m);
 }
 
 void
-tun::ip(std::string const &s, int netmask)
+tuntap::ip(std::string const &s, int netmask)
 {
     tuntap_set_ip(_dev, s.c_str(), netmask);
 }
 
 int
-tun::read(void *buf, size_t len)
+tuntap::read(void *buf, size_t len)
 {
 	return tuntap_read(_dev, buf, len);
 }
 
 int
-tun::write(void *buf, size_t len)
+tuntap::write(void *buf, size_t len)
 {
 	return tuntap_write(_dev, buf, len);
 }
 
 void
-tun::nonblocking(bool b)
-{
-    tuntap_set_nonblocking(_dev, int(b));
-}
-
-tap::tap()
-    : _dev{tuntap_init()}, _started{true}
-{
-    if (tuntap_start(_dev, TUNTAP_MODE_ETHERNET, TUNTAP_ID_ANY) == -1) {
-        throw std::runtime_error("tuntap_start failed");
-    }
-}
-
-tap::~tap()
-{
-    if (_started) {
-        tuntap_destroy(_dev);
-    }
-}
-
-tap::tap(tap &&t)
-    : _dev(nullptr)
-{
-    std::swap(t._dev, this->_dev);
-}
-
-
-void
-tap::release()
-{
-    tuntap_release(_dev);
-    _started = false;
-}
-
-std::string
-tap::name() const
-{
-    return tuntap_get_ifname(_dev);
-}
-
-void
-tap::name(std::string const &s)
-{
-    tuntap_set_ifname(_dev, s.c_str());
-}
-
-std::string
-tap::hwaddr() const
-{
-    return tuntap_get_hwaddr(_dev);
-}
-
-void
-tap::hwaddr(std::string const &s)
-{
-    tuntap_set_hwaddr(_dev, s.c_str());
-}
-
-t_tun
-tap::native_handle() const
-{
-    return tuntap_get_fd(this->_dev);
-}
-
-void
-tap::up()
-{
-    tuntap_up(_dev);
-}
-
-void
-tap::down()
-{
-    tuntap_down(_dev);
-}
-
-int
-tap::mtu() const
-{
-    return tuntap_get_mtu(_dev);
-}
-
-void
-tap::mtu(int m)
-{
-    tuntap_set_mtu(_dev, m);
-}
-
-void
-tap::ip(std::string const &s, int netmask)
-{
-    tuntap_set_ip(_dev, s.c_str(), netmask);
-}
-
-int
-tap::read(void *buf, size_t len)
-{
-	return tuntap_read(_dev, buf, len);
-}
-
-int
-tap::write(void *buf, size_t len)
-{
-	return tuntap_write(_dev, buf, len);
-}
-
-void
-tap::nonblocking(bool b)
+tuntap::nonblocking(bool b)
 {
     tuntap_set_nonblocking(_dev, int(b));
 }

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -4,6 +4,8 @@
 
 #include <string>
 #include <memory>
+#include <stdexcept>
+#include <cstddef>
 
 #include <tuntap.h>
 
@@ -30,8 +32,8 @@ class tuntap
   void ip(std::string const &presentation, int netmask);
 
   //IO
-  int read(void *buf, size_t len) noexcept;
-  int write(void *buf, size_t len) noexcept;
+  int read(void *buf, std::size_t len) noexcept;
+  int write(void *buf, std::size_t len) noexcept;
 
   // System
   void release() noexcept;

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -8,54 +8,19 @@
 
 namespace tuntap {
 
-class tun
+class tuntap
 {
  public:
-  tun();
-  ~tun();
-  tun(tun const &) = delete;
-  tun & operator = (tun const &) = delete;
-  tun(tun &&);
+  tuntap(int, int = TUNTAP_ID_ANY);
+  ~tuntap();
+  tuntap(tuntap const &) = delete;
+  tuntap & operator = (tuntap const &) = delete;
+  tuntap(tuntap &&);
 
   // Properties
   std::string name() const;
   void name(std::string const &);
   int mtu() const ;
-  void mtu(int);
-  t_tun native_handle() const;
-
-  // Network
-  void up();
-  void down();
-  void ip(std::string const &presentation, int netmask);
-
-  //IO
-  int read(void *buf, size_t len);
-  int write(void *buf, size_t len);
-
-  // System
-  void release();
-  void nonblocking(bool);
- private:
-  struct device* _dev;
-  bool _started;
-};
-
-class tap
-{
- public:
-  tap();
-  ~tap();
-  tap(tap const &) = delete;
-  tap & operator = (tap const &) = delete;
-  tap(tap &&);
-
-  // Properties
-  std::string name() const;
-  void name(std::string const &);
-  std::string hwaddr() const;
-  void hwaddr(std::string const &);
-  int mtu() const;
   void mtu(int);
   t_tun native_handle() const;
 

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -15,14 +15,14 @@ class tuntap
   ~tuntap();
   tuntap(tuntap const &) = delete;
   tuntap & operator = (tuntap const &) = delete;
-  tuntap(tuntap &&);
+  tuntap(tuntap &&) noexcept;
 
   // Properties
-  std::string name() const;
+  std::string name() const noexcept;
   void name(std::string const &);
-  int mtu() const ;
+  int mtu() const noexcept;
   void mtu(int);
-  t_tun native_handle() const;
+  t_tun native_handle() const noexcept;
 
   // Network
   void up();
@@ -30,11 +30,11 @@ class tuntap
   void ip(std::string const &presentation, int netmask);
 
   //IO
-  int read(void *buf, size_t len);
-  int write(void *buf, size_t len);
+  int read(void *buf, size_t len) noexcept;
+  int write(void *buf, size_t len) noexcept;
 
   // System
-  void release();
+  void release() noexcept;
   void nonblocking(bool);
  private:
   struct device* _dev;

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -2,6 +2,12 @@
 #ifndef LIBTUNTAP_ALY0MA60
 #define LIBTUNTAP_ALY0MA60
 
+#if __cplusplus >= 202002L
+    #define LIBTUNTAP_ALY0MA60_CONSTEXPR constexpr
+#else
+    #define LIBTUNTAP_ALY0MA60_CONSTEXPR
+#endif
+
 #include <string>
 #include <memory>
 #include <stdexcept>
@@ -41,7 +47,7 @@ class tuntap
  private:
   class TunTapDestroyer final {
       public:
-          void operator()(device * dev) const noexcept {
+          LIBTUNTAP_ALY0MA60_CONSTEXPR void operator()(device * dev) const noexcept {
               if (dev)
                   ::tuntap_destroy(dev);
           }

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -3,6 +3,7 @@
 #define LIBTUNTAP_ALY0MA60
 
 #include <string>
+#include <memory>
 
 #include <tuntap.h>
 
@@ -12,7 +13,6 @@ class tuntap
 {
  public:
   tuntap(int, int = TUNTAP_ID_ANY);
-  ~tuntap();
   tuntap(tuntap const &) = delete;
   tuntap & operator = (tuntap const &) = delete;
   tuntap(tuntap &&) noexcept;
@@ -37,8 +37,14 @@ class tuntap
   void release() noexcept;
   void nonblocking(bool);
  private:
-  struct device* _dev;
-  bool _started;
+  class TunTapDestroyer final {
+      public:
+          void operator()(device * dev) const noexcept {
+              if (dev)
+                  ::tuntap_destroy(dev);
+          }
+  };
+  std::unique_ptr<device, TunTapDestroyer> _dev;
 };
 
 } /* tuntap */


### PR DESCRIPTION
Hello,

when I was working with the libtuntap in C++, I noticed a few things about the wrapper:
There are two different classes for tun devices and for tap devices. This is very inconvenient with memory allocation, since C/C++ has static typing. However, if you want to decide at runtime (e.g. based on configuration files) whether to use Tun or Tap, this is unfavorable.
One way to solve this would be to use a common parent class. However, since only the call to tuntap_start changes, a variable in the constructor makes more sense in my understanding.
Furthermore, there was no way to specify the tunnel ID.
Furthermore, there was faulty error handling. In my tests (it was my fault) I had the case that the interface name could not be set. This was not reported back. Instead, the function simply logged an output and pretended that everything was OK.

This is my attempt to improve these points. I also made a few beauty corrections. I also added an argument validation, which recognizes very simple errors and then throws an exception.