### PR TITLE
Add timeout option to cpp bindings

### DIFF
--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -94,15 +94,23 @@ tuntap::ip(std::string const &s, int netmask)
 }
 
 int
-tuntap::read(void *buf, std::size_t len) noexcept
+tuntap::read(void *buf, std::size_t len, int timeout_ms) noexcept
 {
-	return ::tuntap_read(_dev.get(), buf, len);
+	if (0 == timeout_ms) {
+		return ::tuntap_read(_dev.get(), buf, len);
+	} else {
+		return ::tuntap_read_tm(_dev.get(), buf, len, timeout_ms);
+	}
 }
 
 int
-tuntap::write(void *buf, std::size_t len) noexcept
+tuntap::write(void *buf, std::size_t len, int timeout_ms) noexcept
 {
-	return ::tuntap_write(_dev.get(), buf, len);
+	if (0 == timeout_ms) {
+		return ::tuntap_write(_dev.get(), buf, len);
+	} else {
+		return ::tuntap_write_tm(_dev.get(), buf, len, timeout_ms);
+	}
 }
 
 void

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -39,8 +39,8 @@ class tuntap
 	void ip(std::string const &presentation, int netmask);
 
 	// IO
-	int read(void *buf, std::size_t len) noexcept;
-	int write(void *buf, std::size_t len) noexcept;
+	int read(void *buf, std::size_t len, int timeout_ms = 0) noexcept;
+	int write(void *buf, std::size_t len, int timeout_ms = 0) noexcept;
 
 	// System
 	void release() noexcept;


### PR DESCRIPTION
The C interface has a read and write function that accept a timeout option. This pull request will add a timeout option to the cpp binding by specifying an additional parameter that is default initialized to zero, so the present interface will not be broken.