### PR TITLE
Prevent re-initialization

### DIFF
--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -18,7 +18,7 @@ tuntap::tuntap(int mode, int id)
 }
 
 tuntap::tuntap(tuntap &&t) noexcept
-    : _dev{::tuntap_init(), TunTapDestroyer(false)}
+    : _dev{nullptr, TunTapDestroyer()}
 {
 	t._dev.swap(this->_dev);
 }


### PR DESCRIPTION
Prevent re-initialization in the move constructor. This is unnecessary and not expected. However, to ensure the destructor works, the pointer is initialized to nullptr. The destructor then does not call {tuntap_release,destroy}. This should improve performance slightly.

Following https://github.com/LaKabane/libtuntap/issues/73