### PR TITLE
Make filename case compatible to mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(WIN32)
 
     # Windows specific dependencies
     # -----------------------------
-    target_link_libraries(tuntap PUBLIC Ws2_32)
+    target_link_libraries(tuntap PUBLIC ws2_32)
 endif(WIN32)
 
 # OS specific things

--- a/private.h
+++ b/private.h
@@ -17,7 +17,7 @@
 #include <sys/types.h>
 
 #if defined Windows
-#include <In6addr.h>
+#include <in6addr.h>
 #include <stdint.h>
 #else /* Unix */
 #include <sys/socket.h>


### PR DESCRIPTION
The mingw cross compiler (running on linux) depends on case dependent filenames. The usual convention is to use lower case.

This pull request changes the filenames in two places to lower case. For one a include file and second as a library that need to be linked.

Changing the filenames to lower case should not disturb the native windows compilation since the file system names are [case insensitive on windows](https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity) by default.

