### PR TITLE
Fix missing MTU return value on windows

### DIFF
--- a/tuntap-windows.c
+++ b/tuntap-windows.c
@@ -269,7 +269,7 @@ tuntap_get_mtu(struct device *dev)
 		tuntap_log(TUNTAP_LOG_ERR, (const char *)formated_error(L"%1%0", errcode));
 		return -1;
 	}
-	return 0;
+	return mtu;
 }
 
 int


### PR DESCRIPTION
The function tuntap_get_mtu returns -1 if an error occurs and always zero on success instead of the requested mtu value.

This pull request fixes the problem.
