### PR TITLE
Add missing CPP bindings

### DIFF
--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -38,8 +38,36 @@ tuntap::name() const noexcept
 void
 tuntap::name(std::string const &s)
 {
-	if (::tuntap_set_ifname(_dev.get(), s.c_str())) {
+	if (::tuntap_set_hwaddr(_dev.get(), s.c_str())) {
 		throw std::runtime_error("Failed to set ifname");
+	}
+}
+
+std::string
+tuntap::hwaddr() const noexcept
+{
+	return std::string(::tuntap_get_hwaddr(_dev.get()));
+}
+
+void
+tuntap::hwaddr(std::string const &s)
+{
+	if (::tuntap_set_ifname(_dev.get(), s.c_str())) {
+		throw std::runtime_error("Failed to set hwaddr");
+	}
+}
+
+std::string
+tuntap::descr() const noexcept
+{
+	return std::string(::tuntap_get_descr(_dev.get()));
+}
+
+void
+tuntap::descr(std::string const &s)
+{
+	if (::tuntap_set_descr(_dev.get(), s.c_str())) {
+		throw std::runtime_error("Failed to set descr");
 	}
 }
 
@@ -110,6 +138,13 @@ tuntap::nonblocking(bool b)
 {
 	if (::tuntap_set_nonblocking(_dev.get(), static_cast<int>(b))) {
 		throw std::runtime_error("Failed to change non-blocking state for tuntap device");
+	}
+}
+
+void
+tuntap::debug(bool b) {
+	if (::tuntap_set_debug(_dev.get(), static_cast<int>(b))) {
+		throw std::runtime_error("Failed to change debugging state for tuntap device");
 	}
 }
 

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -142,7 +142,8 @@ tuntap::nonblocking(bool b)
 }
 
 void
-tuntap::debug(bool b) {
+tuntap::debug(bool b)
+{
 	if (::tuntap_set_debug(_dev.get(), static_cast<int>(b))) {
 		throw std::runtime_error("Failed to change debugging state for tuntap device");
 	}

--- a/bindings/cpp/tuntap++.cc
+++ b/bindings/cpp/tuntap++.cc
@@ -38,7 +38,7 @@ tuntap::name() const noexcept
 void
 tuntap::name(std::string const &s)
 {
-	if (::tuntap_set_hwaddr(_dev.get(), s.c_str())) {
+	if (::tuntap_set_ifname(_dev.get(), s.c_str())) {
 		throw std::runtime_error("Failed to set ifname");
 	}
 }
@@ -52,7 +52,7 @@ tuntap::hwaddr() const noexcept
 void
 tuntap::hwaddr(std::string const &s)
 {
-	if (::tuntap_set_ifname(_dev.get(), s.c_str())) {
+	if (::tuntap_set_hwaddr(_dev.get(), s.c_str())) {
 		throw std::runtime_error("Failed to set hwaddr");
 	}
 }

--- a/bindings/cpp/tuntap++.hh
+++ b/bindings/cpp/tuntap++.hh
@@ -29,6 +29,10 @@ class tuntap
 	// Properties
 	std::string name() const noexcept;
 	void name(std::string const &);
+	std::string hwaddr() const noexcept;
+	void hwaddr(std::string const &);
+	std::string descr() const noexcept;
+	void descr(std::string const &);
 	int mtu() const noexcept;
 	void mtu(int);
 	t_tun native_handle() const noexcept;
@@ -45,6 +49,7 @@ class tuntap
 	// System
 	void release() noexcept;
 	void nonblocking(bool);
+	void debug(bool);
 
       private:
 	class TunTapDestroyer final


### PR DESCRIPTION
The CPP bindings, as I have learned, are incomplete by now. This pull request tries to change that by adding the missing functions. Please note, that this pull request does contain the timeout parameter changes.

Background: I plan to move forward with the Windows port, but since I am a CPP inclined person I need the CPP bindings to be in place. I don't expect the review to take much time because the changes are all very simple.