### PR TITLE
Add pointer to struct device for sys dep info

### DIFF
--- a/private.h
+++ b/private.h
@@ -96,6 +96,7 @@ struct device {
 	int flags; /* ifr.ifr_flags on Unix */
 	unsigned char hwaddr[ETHER_ADDR_LEN];
 	char if_name[IF_NAMESIZE + 1];
+	void *sys; /* pointer for system dependent data*/
 };
 
 /*

--- a/tuntap.c
+++ b/tuntap.c
@@ -48,6 +48,7 @@ tuntap_init(void)
 	dev->ctrl_sock = -1;
 	dev->flags = 0;
 	tuntap_log = tuntap_log_default;
+	dev->sys = NULL;
 	return dev;
 }
 


### PR DESCRIPTION
The *struct device* is opaque to the user and is used as a handle to the device. In the struct there are already members that have use differing on platform.

I propose to generalize the concept by providing a pointer that can be used by the respective platform code to store private, platform dependent data, as e.g. number of opened device or other state information. The pointer also could be used to replace the non thread safe function in the unix driver i.e. *ether_ntoa* to its thread safe version *ether_ntoa_r* by providing a storage place that is pointed to by *sys*.