### PR TITLE
Return a safe empty description

### DIFF
--- a/tuntap-unix-linux.c
+++ b/tuntap-unix-linux.c
@@ -262,5 +262,5 @@ tuntap_sys_get_descr(struct device *dev)
 {
 	(void)dev;
 	tuntap_log(TUNTAP_LOG_NOTICE, "Your system does not support tuntap_get_descr()");
-	return NULL;
+	return "";
 }


### PR DESCRIPTION
tuntap_sys_get_descr returns a NULL, which makes the C++ wrapping code unnecessarily complicated without benefit. Returning an empty string avoid NULL dereference.