### PR TITLE
Don't undo loghandler if already set up

### DIFF
--- a/tuntap.c
+++ b/tuntap.c
@@ -47,7 +47,8 @@ tuntap_init(void)
 	dev->tun_fd = TUNFD_INVALID_VALUE;
 	dev->ctrl_sock = -1;
 	dev->flags = 0;
-	tuntap_log = tuntap_log_default;
+	if (NULL == tuntap_log)
+		tuntap_log = tuntap_log_default;
 	dev->sys = NULL;
 	return dev;
 }

--- a/tuntap.c
+++ b/tuntap.c
@@ -47,8 +47,9 @@ tuntap_init(void)
 	dev->tun_fd = TUNFD_INVALID_VALUE;
 	dev->ctrl_sock = -1;
 	dev->flags = 0;
-	if (NULL == tuntap_log)
+	if (NULL == tuntap_log) {
 		tuntap_log = tuntap_log_default;
+	}
 	dev->sys = NULL;
 	return dev;
 }


### PR DESCRIPTION
When setting the custom log handler before opening a device the handler will be reset to default causing any log generated during opening going to the wrong (i.e. default) destination instead of the one specified by the user.

This pull request changes the tuntap_init, so the default handler is only set if no handler has been set yet.

In theory the init function has no call to a logger and the logger could be set between init and start. However the C++ wrapper makes this impossible, because the init and start is a single operation from the wrappers perspective, which is good because it follows the RAII design principle.