### PR TITLE
Remove IF_DESCRSIZE from private.h

### DIFF
--- a/private.h
+++ b/private.h
@@ -43,7 +43,6 @@
  * Uniformize macros
  * - ETHER_ADDR_LEN: Magic number from IEEE 802.3
  * - IF_NAMESIZE: Length of interface external name
- * - IF_DESCRSIZE: Length of interface description
  * - TUNSDEBUG: ioctl flag to enable the debug mode of a tun device
  * - TUNFD_INVALID_VALUE: Invalid value for tun_fd
  */
@@ -58,12 +57,6 @@
 #define ETHER_ADDR_LEN ETH_ALEN
 #elif defined Windows
 #define ETHER_ADDR_LEN 6
-#endif
-
-#if defined IFDESCRSIZE
-#define IF_DESCRSIZE IFDESCRSIZE /* OpenBSD */
-#else
-#define IF_DESCRSIZE 1024 /* FreeBSD /sys/net/if.c, ifdescr_maxlen */
 #endif
 
 #if defined TUNSETDEBUG

--- a/tuntap-unix-darwin.c
+++ b/tuntap-unix-darwin.c
@@ -219,5 +219,5 @@ tuntap_sys_get_descr(struct device *dev)
 {
 	(void)dev;
 	tuntap_log(TUNTAP_LOG_NOTICE, "Your system does not support tuntap_get_descr()");
-	return NULL;
+	return "";
 }

--- a/tuntap-unix-freebsd.c
+++ b/tuntap-unix-freebsd.c
@@ -293,7 +293,7 @@ tuntap_sys_get_descr(struct device *dev)
 	ifr.ifr_buffer.length = sizeof ifdesrc;
 	if (ioctl(dev->ctrl_sock, SIOCGIFDESCR, &ifr) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't get the interface description");
-		return NULL;
+		return "";
 	}
 	return ifdesrc;
 }

--- a/tuntap-unix-freebsd.c
+++ b/tuntap-unix-freebsd.c
@@ -44,6 +44,8 @@
 #include "private.h"
 #include "tuntap.h"
 
+#define IF_DESCRSIZE 1024 /* FreeBSD /sys/net/if.c, ifdescr_maxlen */
+
 static int
 tuntap_sys_create_dev(struct device *dev, const char *iftype, int unit)
 {
@@ -267,6 +269,10 @@ tuntap_sys_set_descr(struct device *dev, const char *descr, size_t len)
 	struct ifreq ifr;
 	struct ifreq_buffer ifrbuf;
 
+	if (len > IF_DESCRSIZE) {
+		/* The value will be truncated */
+		tuntap_log(TUNTAP_LOG_WARN, "Parameter 'descr' is too long");
+	}
 	(void)memset(&ifr, '\0', sizeof ifr);
 	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
 	ifrbuf.buffer = (void *)descr;
@@ -277,8 +283,6 @@ tuntap_sys_set_descr(struct device *dev, const char *descr, size_t len)
 		return -1;
 	}
 	return 0;
-	tuntap_log(TUNTAP_LOG_NOTICE, "Your system does not support tuntap_set_descr()");
-	return -1;
 }
 
 char *

--- a/tuntap-unix-netbsd.c
+++ b/tuntap-unix-netbsd.c
@@ -308,5 +308,5 @@ tuntap_sys_get_descr(struct device *dev)
 {
 	(void)dev;
 	tuntap_log(TUNTAP_LOG_NOTICE, "Your system does not support tuntap_get_descr()");
-	return NULL;
+	return "";
 }

--- a/tuntap-unix-openbsd.c
+++ b/tuntap-unix-openbsd.c
@@ -251,7 +251,7 @@ tuntap_sys_get_descr(struct device *dev)
 	ifr.ifr_data = ifdesrc;
 	if (ioctl(dev->ctrl_sock, SIOCGIFDESCR, &ifr) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't get the interface description");
-		return NULL;
+		return "";
 	}
 	return ifdesrc;
 }

--- a/tuntap-unix-openbsd.c
+++ b/tuntap-unix-openbsd.c
@@ -226,13 +226,14 @@ int
 tuntap_sys_set_descr(struct device *dev, const char *descr, size_t len)
 {
 	struct ifreq ifr;
-	(void)len;
 
+	if (len > IFDESCRSIZE) {
+		/* The value will be truncated */
+		tuntap_log(TUNTAP_LOG_WARN, "Parameter 'descr' is too long");
+	}
 	(void)memset(&ifr, '\0', sizeof ifr);
 	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);
-
 	ifr.ifr_data = (void *)descr;
-
 	if (ioctl(dev->ctrl_sock, SIOCSIFDESCR, &ifr) == -1) {
 		tuntap_log(TUNTAP_LOG_ERR, "Can't set the interface description");
 		return -1;
@@ -244,7 +245,7 @@ char *
 tuntap_sys_get_descr(struct device *dev)
 {
 	struct ifreq ifr;
-	static char ifdesrc[IF_DESCRSIZE];
+	static char ifdesrc[IFDESCRSIZE];
 
 	(void)memset(&ifr, 0, sizeof ifr);
 	(void)strlcpy(ifr.ifr_name, dev->if_name, sizeof ifr.ifr_name);

--- a/tuntap-unix.c
+++ b/tuntap-unix.c
@@ -108,17 +108,8 @@ tuntap_set_descr(struct device *dev, const char *descr)
 		tuntap_log(TUNTAP_LOG_ERR, "Invalid parameter 'descr'");
 		return -1;
 	}
-
 	len = strlen(descr);
-	if (len > IF_DESCRSIZE) {
-		/* The value will be troncated */
-		tuntap_log(TUNTAP_LOG_WARN, "Parameter 'descr' is too long");
-	}
-
-	if (tuntap_sys_set_descr(dev, descr, len) == -1) {
-		return -1;
-	}
-	return 0;
+	return tuntap_sys_set_descr(dev, descr, len);
 }
 
 char *


### PR DESCRIPTION
The definition of `IF_DESCRSIZE` in `private.h` doesn't save anything in term of common code so get rid of it.

Also apply #84 to Darwin, FreeBSD, NetBSD and OpenBSD.