### PR TITLE
Remove hardcoded value of 16 for IF_NAMESIZE

### DIFF
--- a/private.h
+++ b/private.h
@@ -50,8 +50,6 @@
 
 #if defined IFNAMSIZ && !defined IF_NAMESIZE
 #define IF_NAMESIZE IFNAMSIZ /* Historical BSD name */
-#elif !defined IF_NAMESIZE
-#define IF_NAMESIZE 16
 #endif
 
 #if defined ETH_ALEN /* Linux */

--- a/private.h
+++ b/private.h
@@ -17,8 +17,16 @@
 #include <sys/types.h>
 
 #if defined Windows
-#include <in6addr.h>
+/* Windows headers are import-order dependent, disable reorder */
+/* clang-format off */
 #include <stdint.h>
+#include <winsock2.h>
+#include <windows.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#include <in6addr.h>
+#include <inaddr.h>
+/* clang-format on */
 #else /* Unix */
 #include <sys/socket.h>
 #endif

--- a/tuntap-windows.c
+++ b/tuntap-windows.c
@@ -21,10 +21,11 @@
 #include <string.h>
 #include <strsafe.h>
 #include <time.h>
-#include <windows.h>
 
 #include "private.h"
 #include "tuntap.h"
+
+#include <wbemidl.h>
 
 /* From OpenVPN tap driver, common.h */
 #define TAP_CONTROL_CODE(request, method) CTL_CODE(FILE_DEVICE_UNKNOWN, request, method, FILE_ANY_ACCESS)

--- a/tuntap_log.c
+++ b/tuntap_log.c
@@ -15,11 +15,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  **/
 
-#if defined Windows
-#include <windows.h>
-#endif
 #include <ctype.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/tuntap_log.c
+++ b/tuntap_log.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2012, PICHOT Fabien Paul Leonard <pichot.fabienATgmail.com>
  * Copyright (c) 2012, Tristan Le Guern <tleguern@bouledef.eu>
  *
@@ -13,7 +13,7 @@
  * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
- **/
+ */
 
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
This definition is an artefact of earlier porting efforts and annoyed @oe1rsa on Windows. It should not be required anymore.